### PR TITLE
Output shape and dtype inference, multioutput inner layers

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,6 +16,10 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
+        tensorflow-version: [2.4.1, 2.5.0]
+        include:
+          - python-version: 3.9
+            tensorflow-version: 2.5.0
 
     steps:
     - uses: actions/checkout@v2
@@ -25,9 +29,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install --upgrade pip setuptools wheel
+        pip install flake8 pytest pytest-isort
+        if [ -f requirements.txt ]; then pip install -r requirements.txt tensorflow==${{ matrix.tensorflow-version }}; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -36,7 +40,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        pytest --isort
     - name: Install
       run: |
         python -m setup install

--- a/keras_list_mapper/keras_list_mapper_test.py
+++ b/keras_list_mapper/keras_list_mapper_test.py
@@ -17,6 +17,7 @@
 import itertools
 import tempfile
 import unittest
+from typing import List, Tuple
 
 import numpy as np
 import tensorflow as tf
@@ -194,7 +195,6 @@ class ListMapperTest(unittest.TestCase):
             def call(self, inputs, *kwargs):
                 state, rt, vals = inputs
                 rt_shape.append(rt.shape)
-                assert isinstance(rt, tf.RaggedTensor)
                 x = tf.reduce_sum(rt, axis=[-1])
                 x = tf.expand_dims(x, -1)
                 state = tf.math.add(state, vals)
@@ -227,7 +227,6 @@ class ListMapperTest(unittest.TestCase):
         class FakeLayer(layers.Layer):
             def call(self, inputs, *kwargs):
                 state, vals = inputs
-                assert isinstance(vals, tf.RaggedTensor)
                 x = tf.reduce_sum(vals, axis=1)
                 if isinstance(x, tf.RaggedTensor):
                     x = x.to_tensor()
@@ -253,7 +252,6 @@ class ListMapperTest(unittest.TestCase):
         class FakeLayer(layers.Layer):
             def call(self, inputs, *kwargs):
                 state, vals = inputs
-                assert isinstance(vals, tf.RaggedTensor)
                 x = tf.reduce_sum(vals, axis=1)
                 if isinstance(x, tf.RaggedTensor):
                     x = x.to_tensor()
@@ -277,7 +275,6 @@ class ListMapperTest(unittest.TestCase):
         class FakeLayer(layers.Layer):
             def call(self, inputs, *kwargs):
                 state, vals = inputs
-                assert isinstance(vals, tf.RaggedTensor)
                 x = tf.reduce_sum(vals, axis=1)
                 if isinstance(x, tf.RaggedTensor):
                     x = x.to_tensor()
@@ -310,3 +307,256 @@ class ListMapperTest(unittest.TestCase):
         ])
         tf.assert_equal(model.predict(rt).to_tensor(),
                         from_json_model.predict(rt).to_tensor())
+
+    def test_multioutput_layer(self):
+        """
+        Tests that ListMapper correctly handles inner layers with multiple
+        outputs.
+        """
+        inner_in1 = layers.Input(shape=(2,))
+        inner_in2 = layers.Input(shape=(3,))
+        inner_vec = layers.Concatenate()([inner_in1, inner_in2])
+        inner_out1 = layers.Dense(1)(inner_vec)
+        inner_out2 = layers.Dense(2)(inner_vec)
+        inner = models.Model([inner_in1, inner_in2], [inner_out1, inner_out2])
+
+        rt1 = tf.constant([[1., 2], [3., 4]])
+
+        c21 = tf.ragged.constant([[1., 2., 3.], [.4, 5., 6.], [7., 8., 9.]])
+        c22 = tf.ragged.constant([[10., 20., 30.], [.40, 50., 60.]])
+        rt2 = tf.ragged.stack([c21, c22])
+
+        in1 = layers.Input(shape=(2,))
+        in2 = layers.Input(shape=(None, 3), ragged=True)
+        mout1, mout2 = ListMapper(inner, batch_inputs=[0])([in1, in2])
+        out1 = layers.Lambda(tf.reduce_sum)(mout1)
+        out2 = layers.Lambda(tf.reduce_sum)(mout2)
+        out = layers.Add()([out1, out2])
+        model = models.Model([in1, in2], out)
+
+        model.compile(loss="mse")
+
+        y = tf.constant([[1.], [1.]])
+        model.fit([rt1, rt2], y=y, verbose=0)
+
+    def test_dtypes(self):
+        """
+        Test that dtypes are correct during graph construction and prediction.
+        """
+
+        inner_in = layers.Input(shape=(3,))
+        inner_out1 = layers.Lambda(lambda x: tf.cast(x, tf.bool))(inner_in)
+        inner_out2 = layers.Lambda(lambda x: tf.cast(x, tf.int32))(inner_in)
+        inner = models.Model(inner_in, [inner_out1, inner_out2])
+
+        inp = layers.Input(shape=(None, 3), ragged=True)
+        mout1, mout2 = ListMapper(inner)([inp])
+        self.assertEqual(mout1.dtype, inner.output[0].dtype)
+        self.assertEqual(mout2.dtype, inner.output[1].dtype)
+        model = models.Model([inp], [mout1, mout2])
+
+        model.compile(loss="mse")
+
+        c21 = tf.ragged.constant([[1., 2., 3.], [.4, 5., 6.], [7., 8., 9.]])
+        c22 = tf.ragged.constant([[10., 20., 30.], [.40, 50., 60.]])
+        rt2 = tf.ragged.stack([c21, c22])
+
+        pred = model.predict([rt2])
+        self.assertEqual(pred[0].dtype, inner.output[0].dtype)
+        self.assertEqual(pred[1].dtype, inner.output[1].dtype)
+
+    def test_multioutput_layer_with_state(self):
+        """
+        Tests that ListMapper correctly handles multi-input,
+        multi-outputs inner layers and state.
+        """
+
+        state = layers.Input(shape=(1,))
+        inner_in1 = layers.Input(shape=(2,))
+        inner_in2 = layers.Input(shape=(3,))
+        inner_vec = layers.Concatenate()([state, inner_in1, inner_in2])
+        inner_out1 = layers.Dense(1)(inner_vec)
+        inner_out2 = layers.Dense(2)(inner_vec)
+        inner = models.Model([state, inner_in1, inner_in2],
+                             [state, inner_out1, inner_out2])
+
+        rt1 = tf.constant([[1., 2], [3., 4]])
+
+        c21 = tf.ragged.constant([[1., 2., 3.], [.4, 5., 6.], [7., 8., 9.]])
+        c22 = tf.ragged.constant([[10., 20., 30.], [.40, 50., 60.]])
+        rt2 = tf.ragged.stack([c21, c22])
+
+        in1 = layers.Input(shape=(2,))
+        in2 = layers.Input(shape=(None, 3), ragged=True)
+        mout1, mout2 = ListMapper(
+            inner, batch_inputs=[0], state_shape=(1,))([in1, in2])
+        out1 = layers.Lambda(tf.reduce_sum)(mout1)
+        out2 = layers.Lambda(tf.reduce_sum)(mout2)
+        out = layers.Add()([out1, out2])
+        model = models.Model([in1, in2], out)
+
+        model.compile(loss="mse")
+
+        y = tf.constant([[1.], [1.]])
+        model.fit([rt1, rt2], y=y, verbose=0)
+
+    def test_lstm_after_list_mapper(self):
+        """ Test that ListMapper can be used as an intermediate layer.
+        """
+
+        inner_in1 = layers.Input(shape=(2,))
+        inner_in2 = layers.Input(shape=(3,))
+        inner_vec = layers.Concatenate()([inner_in1, inner_in2])
+        inner_out = layers.Dense(1)(inner_vec)
+        inner = models.Model([inner_in1, inner_in2], inner_out)
+
+        rt1 = tf.constant([[1., 2], [3., 4]])
+
+        c21 = tf.ragged.constant([[1., 2., 3.], [.4, 5., 6.], [7., 8., 9.]])
+        c22 = tf.ragged.constant([[10., 20., 30.], [.40, 50., 60.]])
+        rt2 = tf.ragged.stack([c21, c22])
+
+        in1 = layers.Input(shape=(2,))
+        in2 = layers.Input(shape=(None, 3), ragged=True)
+        mout = ListMapper(inner, batch_inputs=[0])([in1, in2])
+        lstm = layers.LSTM(4, return_sequences=True)(mout)
+        td = layers.TimeDistributed(layers.Dense(2))(lstm)
+        out = layers.Lambda(tf.reduce_sum)(td)
+        model = models.Model([in1, in2], out)
+
+        model.compile(loss="mse")
+
+        y = tf.constant([[1.], [1.]])
+        model.fit([rt1, rt2], y=y, verbose=0)
+
+    def test_row_split_dtype(self):
+        """
+        Test the the output's row_splits dtype is inherited from the first
+        input.
+        """
+
+        test_dtypes = [
+            (tf.int32, tf.int32),
+            (tf.int32, tf.int64),
+            (tf.int64, tf.int32),
+            (tf.int64, tf.int64),
+        ]
+
+        inner_in1 = layers.Input(shape=(2,))
+        inner_in2 = layers.Input(shape=(3,))
+        inner_vec = layers.Concatenate()([inner_in1, inner_in2])
+        inner = models.Model([inner_in1, inner_in2], inner_vec)
+
+        in1 = layers.Input(shape=(None, 2), ragged=True)
+        in2 = layers.Input(shape=(None, 3), ragged=True)
+        mout = ListMapper(inner)([in1, in2])
+        model = models.Model([in1, in2], mout)
+
+        model.compile(loss="mse")
+
+        c11 = tf.ragged.constant([[1., 2.], [3., .4], [5., 6.]])
+        c12 = tf.ragged.constant([[10., 20.], [30., .40]])
+        rt1 = tf.ragged.stack([c11, c12])
+
+        c21 = tf.ragged.constant([[1., 2., 3.], [.4, 5., 6.], [7., 8., 9.]])
+        c22 = tf.ragged.constant([[10., 20., 30.], [.40, 50., 60.]])
+        rt2 = tf.ragged.stack([c21, c22])
+
+        for rt1_dtype, rt2_dtype in test_dtypes:
+            with self.subTest(rt1_dtype=rt1_dtype, rt2_dtype=rt2_dtype):
+                rt1 = rt1.with_row_splits_dtype(rt1_dtype)
+                rt2 = rt2.with_row_splits_dtype(rt2_dtype)
+                out_rt = model.predict([rt1, rt2])
+                self.assertEqual(out_rt.row_splits.dtype, rt1_dtype)
+
+
+class ComputeOutputShape(unittest.TestCase):
+    """ Test output shape inference. """
+
+    def _runner(self, mapper: ListMapper, test_shapes: List[Tuple]):
+        for inp_shape, exp_shape in test_shapes:
+            with self.subTest(inp_shape=inp_shape, exp_shape=exp_shape):
+                out_shape = mapper.compute_output_shape(inp_shape)
+                if isinstance(exp_shape[0], list):
+                    self.assertEqual(exp_shape,
+                                     [shape.as_list() for shape in out_shape])
+                else:
+                    self.assertEqual(exp_shape, out_shape.as_list())
+
+    def test_single_input_no_state(self):
+
+        test_shapes = [
+            ([None, None, 4], [None, None, 3]),
+            ([5, 12, 1], [5, 12, 3]),
+        ]
+
+        mapper = ListMapper(layers.Dense(3))
+        self._runner(mapper, test_shapes)
+
+    def test_single_input_with_state(self):
+        test_shapes = [
+            ([None, None, 5], [None, None, 7]),
+            ([5, 12, 5], [5, 12, 7]),
+        ]
+
+        state_inp = layers.Input(shape=(2,))
+        inner_in = layers.Input(shape=(5,))
+        inner_vec = layers.Concatenate()([state_inp, inner_in])
+        inner = models.Model([state_inp, inner_in],
+                             [state_inp, inner_vec])
+
+        mapper = ListMapper(inner, state_shape=(2,))
+        self._runner(mapper, test_shapes)
+
+    def test_multiple_input_with_state(self):
+        # Multiple input, with state
+        test_shapes = [
+            ([[None, None, 5], [None, None, 7, 11]], [None, None, 79]),
+            # The second input will be used as time step input since it's not
+            # ragged in the second dim.
+            ([[1, None, 5], [1, 2, 7, 11]], [1, None, 156]),
+        ]
+
+        state_inp = layers.Input(shape=(2,))
+        inner_in0 = layers.Input(shape=(5,))
+        inner_in1 = layers.Input(shape=(7, 11))
+        inner_in1_f = layers.Flatten()(inner_in1)
+        inner_vec = layers.Concatenate()([state_inp, inner_in1_f])
+        inner = models.Model([state_inp, inner_in0, inner_in1],
+                             [state_inp, inner_vec])
+
+        mapper = ListMapper(inner, state_shape=(2,))
+        self._runner(mapper, test_shapes)
+
+    def test_multiple_input_multiple_output_with_state(self):
+        # Multiple input, with state
+        test_shapes = [
+            ([[None, None, 5], [None, None, 7, 11]],
+             [[None, None, 79], [None, None]]),
+
+            # The second input will be used as time step input since it's not
+            # ragged in the second dim.
+            ([[1, None, 5], [1, 2, 7, 11]],
+             [[1, None, 156], [1, None]]),
+        ]
+
+        state_inp = layers.Input(shape=(2,))
+        inner_in0 = layers.Input(shape=(5,))
+        inner_in1 = layers.Input(shape=(7, 11))
+        inner_in1_f = layers.Flatten()(inner_in1)
+        inner_vec = layers.Concatenate()([state_inp, inner_in1_f])
+        inner_dense = layers.Reshape(tuple())(layers.Dense(1)(inner_vec))
+        inner = models.Model([state_inp, inner_in0, inner_in1],
+                             [state_inp, inner_vec, inner_dense])
+
+        mapper = ListMapper(inner, state_shape=(2,))
+        self._runner(mapper, test_shapes)
+
+    def test_single_input_recursive(self):
+        test_shapes = [
+            ([None, None, None, 4], [None, None, None, 3]),
+        ]
+
+        # TODO(DavideWalder): Add full recursive usage support
+        mapper = ListMapper(ListMapper(layers.Dense(3)))
+        self._runner(mapper, test_shapes)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow>=2.3.1
+tensorflow>=2.4


### PR DESCRIPTION
### Changes
- Fixed output shape when running in Keras functional mode. The ragged dimension was missing returning (batch, features...) instead of (batch, ragged dim, features...)
- Expanded test suite to Python 3.9 and Tensorflow 2.5
- Dropped support for Tensorflow<2.4 (closes #13)
- Removed `_type_spec`
- Added `compute_output_shape` (used internally and by other layers to infer the output shape without using `call`)
- Added support for multi-output inner layers.
- Fixed dtype: now multiple output dtypes other than int64 are supported, correctly inferred and predicted.
- Fixed issue where the `ListMapper` wouldn't work if the input's row_split dtype wasn't `tf.int64`

### Notes
- When running `compute_output_shape` on an inner layer that doesn't override it, Keras will run its `call` function with a non-ragged placeholder. This broke the assertions in `FakeLayer`, which was removed. Alternatively, a `compute_output_shape` method could have been defined.
- The implementation for the new features was kept as close as possible to `TimeDistributed`, for consistency.
- RaggedTensorSpec has properties such as `row_splits_dtype` and `ragged_rank` which are not represented in the placeholder returned by `ListMapper.__call__`.